### PR TITLE
Avoid Atribute error when executing admin.py

### DIFF
--- a/pyknyx/tools/adminUtility.py
+++ b/pyknyx/tools/adminUtility.py
@@ -202,5 +202,9 @@ class AdminUtility(object):
 
         # Parse args
         args = mainParser.parse_args()
-        args.func(args)
+        try:
+            args.func(args)
+        except AttributeError:
+            mainParser.print_help()
+            mainParser.exit()
 


### PR DESCRIPTION
when calling, E.g.:
`python3 pyknyx/examples/1_timer/admin.py`
this error ocurrs:
```
Traceback (most recent call last):
File "pyknyx/examples/1_timer/admin.py", line 18, in <module>
main()
File "pyknyx/examples/1_timer/admin.py", line 14, in main
AdminUtility().execute()
File "/usr/local/lib/python3.8/dist-packages/PyKNyX_knxd-2.0.0.dev1-py3.8.egg/pyknyx/tools/adminUtility.py", line 205, in execute
args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```
See:
https://stackoverflow.com/questions/48648036/python-argparse-args-has-no-attribute-func